### PR TITLE
add name to breadcrumbs tag

### DIFF
--- a/src/formatters/breadcrumbs.coffee
+++ b/src/formatters/breadcrumbs.coffee
@@ -4,7 +4,7 @@
 # Set defaults and cast vars
 url = url || process.env.URL
 
-export default ({ breadcrumbsList = [], name }) ->
+export default ({ breadcrumbsList = [], name = 'Breadcrumbs' }) ->
 
 	# Make the breadcrumbs
 	breadcrumbs = breadcrumbsList.map (data, index, array) -> 

--- a/src/formatters/breadcrumbs.coffee
+++ b/src/formatters/breadcrumbs.coffee
@@ -4,7 +4,7 @@
 # Set defaults and cast vars
 url = url || process.env.URL
 
-export default (breadcrumbsList = []) ->
+export default ({ breadcrumbsList = [], name }) ->
 
 	# Make the breadcrumbs
 	breadcrumbs = breadcrumbsList.map (data, index, array) -> 
@@ -19,6 +19,7 @@ export default (breadcrumbsList = []) ->
 	{
 		"@context": "https://schema.org"
 		"@type": "BreadcrumbList",
+		name
 		"itemListElement": breadcrumbs
 	}
 


### PR DESCRIPTION
Add name option to resolve the issue where breadcrumbs would appear as unnamed on google rich text results. 
![image](https://user-images.githubusercontent.com/59039840/159771565-bdd75e48-9ff6-4aac-8fc5-59498aeff1c4.png)
